### PR TITLE
Adds browser and node fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/dist.node.js",
   "scripts": {
     "build": "npx webpack --progress",
+    "prepare": "npm run build",
     "watch": "npx webpack -w --progress",
     "dist": "NODE_ENV=production npx webpack",
     "test": "npx jest"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "2.1.1",
   "description": "Brickadia Save Read/Writing",
   "main": "index.js",
+  "browser": "dist/dist.web.js",
+  "module": "dist/dist.node.js",
   "scripts": {
     "build": "npx webpack --progress",
     "watch": "npx webpack -w --progress",


### PR DESCRIPTION
Webpack/Next.js's Turbopack were not very happy with index.js since it's a dynamic export. We can bypass the need for it by specifying `browser` and `module` within package.json

(Please bump npm version after merging this)